### PR TITLE
Prevent plugin from including the wrong `functions.php`

### DIFF
--- a/acf-advanced-taxonomy-selector/trunk/acf-advanced_taxonomy_selector.php
+++ b/acf-advanced-taxonomy-selector/trunk/acf-advanced_taxonomy_selector.php
@@ -12,7 +12,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 */
 
 // Include Common Functions
-include( 'functions.php' );
+include dirname( __FILE__ ) . '/functions.php';
 
 
 add_action('plugins_loaded', 'acfatf_load_textdomain');
@@ -41,7 +41,7 @@ add_action('acf/include_field_types', 'include_field_types_advanced_taxonomy_sel
  *
  */
 function include_field_types_advanced_taxonomy_selector( $version ) {
-	include_once('acf-advanced_taxonomy_selector-v5.php');
+	include_once dirname( __FILE__ ) . '/acf-advanced_taxonomy_selector-v5.php';
 }
 
 
@@ -56,7 +56,7 @@ add_action('acf/register_fields', 'register_fields_advanced_taxonomy_selector');
  *
  */
 function register_fields_advanced_taxonomy_selector() {
-	include_once('acf-advanced_taxonomy_selector-v4.php');
+	include_once dirname( __FILE__ ) . '/acf-advanced_taxonomy_selector-v4.php';
 }
 
 


### PR DESCRIPTION
Without a prefix, PHP refers to the `include_path`, which
includes the working directory. When called during a unit test,
the working directory will be that of the theme or plugin under
test, not the typical entry path for WordPress. As a result,
the `include( 'functions.php' );` line was prone to include a
theme's `functions.php` prematurely, rather than including the
plugin's file as intended. Prefixing the include path with `./`
would have a similar effect, but there's no downside to being
explicit.